### PR TITLE
Add project repo URL

### DIFF
--- a/email_updates.sh
+++ b/email_updates.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
 
+# Official project URL: https://github.com/WhyAskWhy/email-updates
+
+
 # Purpose:
 #   This script is intended to be run once daily to report any patches
 #   available for the OS. If a particular patch has been reported previously


### PR DESCRIPTION
Since we no longer have SVN keywords to point user to upstream
project, we add an explicit URL to official Git repo/project.