### PR TITLE
Require vars to be initialized, exit on non-true

### DIFF
--- a/email_updates.sh
+++ b/email_updates.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# Do not allow use of unitilized variables
+set -u
+
+# Exit if any statement returns a non-true value
+set -e
 
 # Purpose:
 #   This script is intended to be run once daily to report any patches


### PR DESCRIPTION
Using 'set -u' and 'set -e', both of which appear to be
best practice flags for Bash scripting.

Setting these now in an effort to help troubleshoot why
the script occasionally returns a directory listing
in place of available updates.

refs whyaskwhy/email-updates#9