### PR TITLE
Enable pipefail flag

### DIFF
--- a/email_updates.sh
+++ b/email_updates.sh
@@ -6,6 +6,12 @@ set -u
 # Exit if any statement returns a non-true value
 set -e
 
+# Exit if ANY command in a pipeline fails instead of allowing the exit code
+# of later commands in the pipeline to determine overall success
+set -o pipefail
+
+
+
 # Official project URL: https://github.com/WhyAskWhy/email-updates
 
 


### PR DESCRIPTION
This is to force early exit if any command in a pipeline
fails instead of allowing the last exit code in the pipeline
from determining overall success/failure.

Not directly related, but this should prove useful in helping
to narrow down the specific cause of invalid patch reports
as noted on the related ticket.

refs whyaskwhy/email-updates#9