### PR TITLE
Add very basic support for email header, footer

### DIFF
--- a/email_updates.conf.example
+++ b/email_updates.conf.example
@@ -1,0 +1,10 @@
+
+# Example include file for the email_updates.sh script
+
+DEBUG_ON=0
+EMAIL_TAG_PROJECT="servers-general"
+EMAIL_TAG_CATEGORY="OS Patches"
+EMAIL_DEST="ticketing-system-intake-address@example.com"
+
+EMAIL_HEADER="The following updates are available for installation:"
+EMAIL_FOOTER="{{include(docs:How_to_apply_patches_to_our_systems)}}"

--- a/email_updates.sh
+++ b/email_updates.sh
@@ -365,6 +365,9 @@ email_report() {
     NUMBER_OF_UPDATES="${#updates[@]}"
     EMAIL_SUBJECT="${HOSTNAME}: ${NUMBER_OF_UPDATES} update(s) are available"
 
+    # TODO: Add guard for this variable not existing (new feature as of v0.3)
+    echo -e "${EMAIL_HEADER}\n" >> ${TEMP_FILE}
+
     # Write updates to the temp file
     for update in "${updates[@]}"
     do
@@ -388,6 +391,9 @@ email_report() {
         echo $(ifconfig | grep -Po "${MATCH_IFCONFIG_FULL}" | grep -v '127.0.0' | grep -Po "${MATCH_IFCONFIG_IPS_ONLY}") >> ${TEMP_FILE}
 
     fi
+
+    # TODO: Add guard for this variable not existing (new feature as of v0.3)
+    echo -e "\n${EMAIL_FOOTER}\n" >> ${TEMP_FILE}
 
     # Send the report via email
     # If user chose to masquerade this email as a specific user, set the value


### PR DESCRIPTION
- Add EMAIL_HEADER, EMAIL_FOOTER conf file options
- Add example conf file to illustrate currently supported   options. Future supported options should be added to the file to showcase their use.

This support can be further enhanced, this is just so I can start *using* the support in an effort to get a better idea of the final form.

refs WhyAskWhy/email-updates#5
